### PR TITLE
Update to model_selection

### DIFF
--- a/tensorflow/examples/learn/iris.py
+++ b/tensorflow/examples/learn/iris.py
@@ -16,7 +16,7 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-from sklearn import cross_validation
+from sklearn import model_selection
 from sklearn import metrics
 import tensorflow as tf
 
@@ -24,7 +24,7 @@ import tensorflow as tf
 def main(unused_argv):
   # Load dataset.
   iris = tf.contrib.learn.datasets.load_dataset('iris')
-  x_train, x_test, y_train, y_test = cross_validation.train_test_split(
+  x_train, x_test, y_train, y_test = model_selection.train_test_split(
       iris.data, iris.target, test_size=0.2, random_state=42)
 
   # Build 3 layer DNN with 10, 20, 10 units respectively.


### PR DESCRIPTION
sklearn cross_validation is deprecated and throws a warning.  Fixed the issue by replacing it with the recommended model_selection.